### PR TITLE
Fix:input_validation_phone

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SelectField, SubmitField , validators #imported the validators
-from wtforms.validators import DataRequired , Regexp#imported the data required
+from wtforms import StringField, SelectField, SubmitField  
+from wtforms.validators import DataRequired , Regexp , ValidationError #imported the data required
 
 class ContactForm(FlaskForm):
     name = StringField('Name',
@@ -8,7 +8,20 @@ class ContactForm(FlaskForm):
                        validators=[DataRequired(message='Name is required'),
                                    #regex added to name so its only letters and not number
                                       Regexp(r'^[a-zA-Z ]*$', message="Name must be letters only")]) #validator added for name, also imported the validator
-    phone = StringField('Phone')
+    #validator added to ensure it's not empty.
+    phone = StringField('Phone', validators=[DataRequired(message="Phone number is required")])
+# Custom phone number validator function to add additional checks for phone format.
+    def validate_phone(form, field):
+    # Get the value entered in the phone field.
+        phone_number = field.data
+    # Check if the phone number contains only digits.
+        if not phone_number.isdigit():
+        # If the phone number has non-numeric characters, raise a validation error.
+          raise ValidationError("Phone number must be numeric.")
+    # Check if the phone number length is exactly 8 digits.
+        if len(phone_number) != 8:
+        # If the phone number length is not 8, raise a validation error.
+         raise ValidationError("Phone number must be exactly 8 digits.")
     email = StringField('Email')
     type = SelectField('Type', 
                       choices=[('Personal', 'Personal'), 


### PR DESCRIPTION
Adds input validation for the phone field in the contact form to ensure it only not accept numbers upto 8(assuming its a Qatar number).
Implemented a custom validator using WTForms to check that the phone field is non-empty and contains only numbers.
Review the validation logic in the ContactForm class to ensure it behaves as expected.

<img width="224" alt="image" src="https://github.com/user-attachments/assets/1116283f-53e6-4cb9-af7a-3f3007cd2f82" />

![image](https://github.com/user-attachments/assets/f02aaf29-a065-4148-938d-d1264ea47ed3)

